### PR TITLE
Developログイン時にitemのindex.html.erbになるよう設定

### DIFF
--- a/app/assets/stylesheets/item.scss
+++ b/app/assets/stylesheets/item.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the item controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
 end

--- a/app/controllers/item_controller.rb
+++ b/app/controllers/item_controller.rb
@@ -1,0 +1,20 @@
+class ItemController < ApplicationController
+  def index
+    #user情報を取り出す
+    @user  = current_user
+    #itemの情報を全て取り出す
+    @items = Item.all
+  end
+
+  def show
+  end
+
+  def create
+  end
+
+  def update
+  end
+
+  def delete
+  end
+end

--- a/app/helpers/item_helper.rb
+++ b/app/helpers/item_helper.rb
@@ -1,0 +1,2 @@
+module ItemHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,2 @@
+class Item < ApplicationRecord
+end

--- a/app/views/item/create.html.erb
+++ b/app/views/item/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Item#create</h1>
+<p>Find me in app/views/item/create.html.erb</p>

--- a/app/views/item/delete.html.erb
+++ b/app/views/item/delete.html.erb
@@ -1,0 +1,2 @@
+<h1>Item#delete</h1>
+<p>Find me in app/views/item/delete.html.erb</p>

--- a/app/views/item/index.html.erb
+++ b/app/views/item/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Item#index</h1>
+<p>Find me in app/views/item/index.html.erb</p>

--- a/app/views/item/show.html.erb
+++ b/app/views/item/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Item#show</h1>
+<p>Find me in app/views/item/show.html.erb</p>

--- a/app/views/item/update.html.erb
+++ b/app/views/item/update.html.erb
@@ -1,0 +1,2 @@
+<h1>Item#update</h1>
+<p>Find me in app/views/item/update.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  get 'item/index'
+  get 'item/show'
+  get 'item/create'
+  get 'item/update'
+  get 'item/delete'
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
   get 'item/create'
   get 'item/update'
   get 'item/delete'
+
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-
+  root to: 'item#index'
 end

--- a/db/migrate/20230511013646_create_items.rb
+++ b/db/migrate/20230511013646_create_items.rb
@@ -1,0 +1,13 @@
+class CreateItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :items do |t|
+      t.string :name,                 nill: false, default: ""
+      t.text :explanation,            nill: false, default: ""
+      t.integer :price,               nill: false, default: ""
+      t.string :seller_id,            nill: false, default: ""
+      t.string :buyer_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_09_113505) do
+ActiveRecord::Schema.define(version: 2023_05_11_013646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "items", force: :cascade do |t|
+    t.string "name", default: ""
+    t.text "explanation", default: ""
+    t.integer "price"
+    t.string "seller_id", default: ""
+    t.string "buyer_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", default: ""

--- a/test/controllers/item_controller_test.rb
+++ b/test/controllers/item_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class ItemControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get item_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get item_show_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get item_create_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get item_update_url
+    assert_response :success
+  end
+
+  test "should get delete" do
+    get item_delete_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  explanation: MyText
+  price: 1
+  seller_id: MyString
+  buyer_id: MyString
+
+two:
+  name: MyString
+  explanation: MyText
+  price: 1
+  seller_id: MyString
+  buyer_id: MyString

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
目的：
ログイン時に商品一覧へ行きたいので「root to: 'item#index'」を設定したいです。

内容：
routes.rbに「root to: 'item#index'」を設定を設定しました。また、ログインをしていないユーザーに対して、指定したアクションを実行する前にログインを求めたいためApplicationController.rbに「before_action :authenticate_user!」を指定しました。

備考：
プルリクエストではコードレビューが目的となるため、モデル作成やコントローラー作成ではプルリクは必要ないかと思われますが、１つのブランチ（developブランチ）で操作をすると、これらの差分まで反映されてしまいます。現に今回はその分の差分が入ってしまっております。

そのため、もしモデル作成やコントローラー作成をプルリクに含めないようにするためには、別ブランチを新たに作り、そこでモデル作成やコントローラー作成をすることで対応できるかと思いましたが、現場ではモデル作成やコントローラー作成はどのように行いますでしょうか？


<img width="475" alt="スクリーンショット 2023-05-11 11 19 34" src="https://github.com/shinke1171718/furima_app/assets/110751171/e10faca0-3e87-4d9e-a5a8-66f69dcc6f62">
<img width="413" alt="スクリーンショット 2023-05-11 11 21 39" src="https://github.com/shinke1171718/furima_app/assets/110751171/81e08e76-a3d1-4fce-b804-2b2448d2e376">
