### PR TITLE
“ログイン時にnameとパスワードでログインできるよう調整”

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,12 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    added_attrs = [:name, :email, :password, :password_confirmation, :remember_me]
+    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+    devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,8 +2,8 @@
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
   </div>
 
   <div class="field">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  # config.authentication_keys = [:name]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the


### PR DESCRIPTION
目的：
ログイン時にemailを入力するのは手間になるため、nameとパスワードでログインできるように修正したいです。

内容：
nameとパスワードでログインできるように、
・app/controllers/application_controller.rbに「configure_permitted_parametersメソッド」を設定
・app/views/devise/sessions/new.html.erbにnameを記述できるようviewを修正
・config/initializers/devise.rbにある「config.authentication_keys = [:email]」をnameへ修正
上記3点を記述いたしました。

<img width="467" alt="スクリーンショット 2023-05-11 12 19 30" src="https://github.com/shinke1171718/furima_app/assets/110751171/75eeb3ba-0066-441e-bcc5-5d90993fa30d">
<img width="1003" alt="スクリーンショット 2023-05-11 12 22 23" src="https://github.com/shinke1171718/furima_app/assets/110751171/62cb522d-4749-4b2f-a4e5-03fff5c58c76">
<img width="979" alt="スクリーンショット 2023-05-11 12 25 33" src="https://github.com/shinke1171718/furima_app/assets/110751171/3029c376-04a3-45ec-bfda-91f8fec26ab7">
