### PR TITLE
削除したapplication_controllerを復元とbinding.pryができるようgemをインストールしました。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
 gem 'pg'
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -127,6 +128,9 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.5.3)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -239,6 +243,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg
+  pry
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.7, >= 6.1.7.2)


### PR DESCRIPTION
目的：
・消えたapplication_controllerを再度作成
・「binding.pry」でデバックができるようにするため

内容：
プルリク時にFiles changedでfile deleteをするとリモート上でファイルが消えてしまっていたため、application_controllerを再度作成しました。またgem fileにgem 'pry'をインストールしました。