### PR TITLE
Rails7.0.4.3以降使用できないメソッドのため削除しました。

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,7 +310,4 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
-
-  config.sign_out_via = :delete
-  config.after_sign_out_path_for = :root_path
 end


### PR DESCRIPTION
目的：
Rails7.0.4.3以降使用できないメソッドのため削除しました。

内容：
「config.sign_out_via = :delete」と「config.after_sign_out_path_for = :root_path」の行を削除しました。
もともとデフォルトで実装されている機能のため、そのまま削除のみ行います。